### PR TITLE
fix: segfault when rank is too big

### DIFF
--- a/src/tucucore/computingcomponent.cpp
+++ b/src/tucucore/computingcomponent.cpp
@@ -50,6 +50,8 @@
 #include "tucucore/residualerrormodelextractor.h"
 #include "tucucore/treatmentdrugmodelcompatibilitychecker.h"
 
+#include "definitions.h"
+
 namespace Tucuxi {
 namespace Core {
 
@@ -427,6 +429,12 @@ ComputingStatus ComputingComponent::compute(
 #ifdef NO_PERCENTILES
     return ComputingStatus::NoPercentilesCalculation;
 #endif
+
+    for (const auto& rank : _traits->getRanks()) {
+        if (rank > PERCENTILE_RANK_MAX || rank < PERCENTILE_RANK_MIN) {
+            return ComputingStatus::OutOfBoundsPercentileRank;
+        }
+    }
     if (_request.getDrugModel().getAnalyteSets().size() > 1) {
         return computePercentilesMulti(_traits, _request, _response);
     }

--- a/src/tucucore/computingservice/computingresult.h
+++ b/src/tucucore/computingservice/computingresult.h
@@ -134,7 +134,10 @@ enum class [[nodiscard]] ComputingStatus{
         /// The dosage history is empty, but should not be
         NoDosageHistory,
         /// There is at least one sample before the treatment start
-        SampleBeforeTreatmentStart};
+        SampleBeforeTreatmentStart,
+        /// At least one percentile rank is out of bounds
+        OutOfBoundsPercentileRank,
+};
 
 std::ostream& operator<<(std::ostream& _stream, const ComputingStatus& _e);
 

--- a/src/tucucore/definitions.h
+++ b/src/tucucore/definitions.h
@@ -247,6 +247,9 @@ typedef std::vector<Concentrations> MultiCycleConcentrations;
 /// Percentile rank, between 0.0 and 100.0
 typedef double PercentileRank;
 
+constexpr double PERCENTILE_RANK_MAX = 100.;
+constexpr double PERCENTILE_RANK_MIN = 0.;
+
 /// \ingroup TucuCore
 /// Vector of percentile ranks, each one being between 0.0 and 100.0
 typedef std::vector<PercentileRank> PercentileRanks;

--- a/src/tucuquery/queryimport.cpp
+++ b/src/tucuquery/queryimport.cpp
@@ -22,6 +22,7 @@
 
 #include "queryimport.h"
 
+#include "tucucommon/loggerhelper.h"
 #include "tucucommon/utils.h"
 #include "tucucommon/xmlattribute.h"
 #include "tucucommon/xmldocument.h"
@@ -890,10 +891,19 @@ unique_ptr<RequestData> QueryImport::createRequest(Tucuxi::Common::XmlNodeIterat
 Tucuxi::Core::PercentileRanks QueryImport::getChildPercentileRanks(
         Common::XmlNodeIterator _rootIterator, const string& _childName)
 {
+    Common::LoggerHelper logger;
     Common::XmlNodeIterator it = _rootIterator->getChildren(_childName);
     Tucuxi::Core::PercentileRanks ranks;
     while (it != Common::XmlNodeIterator::none()) {
         Tucuxi::Core::PercentileRank rank = extractDouble(it);
+        if (rank > Core::PERCENTILE_RANK_MAX) {
+            logger.warn("Percentile Rank is too big ({}). Using {} instead", rank, Core::PERCENTILE_RANK_MAX);
+            rank = Core::PERCENTILE_RANK_MAX;
+        }
+        else if (rank < Core::PERCENTILE_RANK_MIN) {
+            logger.warn("Percentile Rank is too small ({}). Using {} instead", rank, Core::PERCENTILE_RANK_MIN);
+            rank = Core::PERCENTILE_RANK_MIN;
+        }
         ranks.push_back(rank);
         it++;
     }

--- a/src/tucuquery/queryimport.cpp
+++ b/src/tucuquery/queryimport.cpp
@@ -891,7 +891,6 @@ unique_ptr<RequestData> QueryImport::createRequest(Tucuxi::Common::XmlNodeIterat
 Tucuxi::Core::PercentileRanks QueryImport::getChildPercentileRanks(
         Common::XmlNodeIterator _rootIterator, const string& _childName)
 {
-    Common::LoggerHelper logger;
     Common::XmlNodeIterator it = _rootIterator->getChildren(_childName);
     Tucuxi::Core::PercentileRanks ranks;
     while (it != Common::XmlNodeIterator::none()) {

--- a/src/tucuquery/queryimport.cpp
+++ b/src/tucuquery/queryimport.cpp
@@ -896,13 +896,9 @@ Tucuxi::Core::PercentileRanks QueryImport::getChildPercentileRanks(
     Tucuxi::Core::PercentileRanks ranks;
     while (it != Common::XmlNodeIterator::none()) {
         Tucuxi::Core::PercentileRank rank = extractDouble(it);
-        if (rank > Core::PERCENTILE_RANK_MAX) {
-            logger.warn("Percentile Rank is too big ({}). Using {} instead", rank, Core::PERCENTILE_RANK_MAX);
-            rank = Core::PERCENTILE_RANK_MAX;
-        }
-        else if (rank < Core::PERCENTILE_RANK_MIN) {
-            logger.warn("Percentile Rank is too small ({}). Using {} instead", rank, Core::PERCENTILE_RANK_MIN);
-            rank = Core::PERCENTILE_RANK_MIN;
+        if (rank > Core::PERCENTILE_RANK_MAX || rank < Core::PERCENTILE_RANK_MIN) {
+            setNodeError(it);
+            break;
         }
         ranks.push_back(rank);
         it++;

--- a/test/tucuquery/CMakeLists.txt
+++ b/test/tucuquery/CMakeLists.txt
@@ -31,6 +31,7 @@ file(GLOB TUCUTESTQUERY_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/gtest_mod202.cpp
     ${CMAKE_CURRENT_LIST_DIR}/gtest_query.cpp
     ${CMAKE_CURRENT_LIST_DIR}/gtest_query1comp.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/gtest_queryimport.cpp
 )
 
 add_executable(tucutestquery ${TUCUTESTQUERY_HEADER_FILES} ${TUCUTESTQUERY_SOURCE_FILES})

--- a/test/tucuquery/gtest_queryimport.cpp
+++ b/test/tucuquery/gtest_queryimport.cpp
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+
+#include "tucucore/definitions.h"
+
+#include "tucuquery/queryimport.h"
+
+#include "gtest_queryinputstrings.h"
+
+TEST(Query_TestQueryImport, TestInvalidRank)
+{
+    Tucuxi::Query::QueryImport importer;
+    std::unique_ptr<Tucuxi::Query::QueryData> data;
+    Tucuxi::Query::QueryImport::Status importResult = importer.importFromString(data, tqf_invalid_rank);
+
+
+    auto computingTrait =
+            dynamic_cast<Tucuxi::Core::ComputingTraitPercentiles&>(data->getRequests()[0]->getpComputingTrait());
+
+    ASSERT_FLOAT_EQ(computingTrait.getRanks()[0], Tucuxi::Core::PERCENTILE_RANK_MIN);
+    ASSERT_FLOAT_EQ(computingTrait.getRanks()[1], Tucuxi::Core::PERCENTILE_RANK_MIN);
+    ASSERT_FLOAT_EQ(computingTrait.getRanks()[2], Tucuxi::Core::PERCENTILE_RANK_MAX);
+    ASSERT_FLOAT_EQ(computingTrait.getRanks()[3], Tucuxi::Core::PERCENTILE_RANK_MAX);
+}

--- a/test/tucuquery/gtest_queryimport.cpp
+++ b/test/tucuquery/gtest_queryimport.cpp
@@ -1,7 +1,5 @@
 #include <gtest/gtest.h>
 
-#include "tucucore/definitions.h"
-
 #include "tucuquery/queryimport.h"
 
 #include "gtest_queryinputstrings.h"
@@ -12,12 +10,5 @@ TEST(Query_TestQueryImport, TestInvalidRank)
     std::unique_ptr<Tucuxi::Query::QueryData> data;
     Tucuxi::Query::QueryImport::Status importResult = importer.importFromString(data, tqf_invalid_rank);
 
-
-    auto computingTrait =
-            dynamic_cast<Tucuxi::Core::ComputingTraitPercentiles&>(data->getRequests()[0]->getpComputingTrait());
-
-    ASSERT_FLOAT_EQ(computingTrait.getRanks()[0], Tucuxi::Core::PERCENTILE_RANK_MIN);
-    ASSERT_FLOAT_EQ(computingTrait.getRanks()[1], Tucuxi::Core::PERCENTILE_RANK_MIN);
-    ASSERT_FLOAT_EQ(computingTrait.getRanks()[2], Tucuxi::Core::PERCENTILE_RANK_MAX);
-    ASSERT_FLOAT_EQ(computingTrait.getRanks()[3], Tucuxi::Core::PERCENTILE_RANK_MAX);
+    ASSERT_EQ(importResult, Tucuxi::Query::QueryImport::Status::Error);
 }

--- a/test/tucuquery/gtest_queryinputstrings.h
+++ b/test/tucuquery/gtest_queryinputstrings.h
@@ -745,5 +745,151 @@ static const std::string tqf = R"(<?xml version='1.0' ?>
 </query>)";
 
 
+static const std::string tqf_invalid_rank = R"(<?xml version='1.0' ?>
+<query version='1.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='xml_query.xsd'>
+	<queryId>2_ch.tucuxi.virtualdrug.mod1</queryId>
+	<clientId>2</clientId>
+	<date>2023-09-13T10:53:20</date>
+	<!-- Date the xml has been sent -->
+	<language>en</language>
+	<drugTreatment>
+		<!-- All the information regarding the patient -->
+		<patient>
+			<covariates>
+				<covariate>
+					<covariateId>birthdate</covariateId>
+					<date>2023-01-01T00:00:00</date>
+					<value>2023-01-01T00:00:00</value>
+					<unit/>
+					<dataType>date</dataType>
+					<nature>discrete</nature>
+				</covariate>
+				<covariate>
+					<covariateId>sampling_group</covariateId>
+					<date>2023-01-01T00:00:00</date>
+					<value>1</value>
+					<unit/>
+					<dataType>int</dataType>
+					<nature>discrete</nature>
+				</covariate>
+			</covariates>
+		</patient>
+		<!-- List of the drugs informations we have concerning the patient -->
+		<drugs>
+			<!-- All the information regarding the drug -->
+			<drug>
+				<drugId>virtualdrug</drugId>
+				<activePrinciple>virtualdrug</activePrinciple>
+				<brandName/>
+				<atc/>
+				<!-- All the information regarding the treatment -->
+				<treatment>
+					<dosageHistory>
+						<dosageTimeRange>
+							<start>2023-01-01T08:00:00</start>
+							<end>2023-01-02T08:00:00</end>
+							<dosage>
+								<dosageLoop>
+									<lastingDosage>
+										<interval>24:0:0</interval>
+										<dose>
+											<value>120</value>
+											<unit>mg</unit>
+											<infusionTimeInMinutes>60.0</infusionTimeInMinutes>
+										</dose>
+										<formulationAndRoute>
+											<formulation>oralSolution</formulation>
+											<administrationName>foo bar</administrationName>
+											<administrationRoute>oral</administrationRoute>
+											<absorptionModel>extra</absorptionModel>
+										</formulationAndRoute>
+									</lastingDosage>
+								</dosageLoop>
+							</dosage>
+						</dosageTimeRange>
+					</dosageHistory>
+				</treatment>"
+                    R"(
+				<!-- Samples history -->
+				<samples>
+					<sample>
+						<sampleId>c1</sampleId>
+						<sampleDate>2023-01-01T09:00:00</sampleDate>
+						<concentrations>
+							<concentration>
+								<analyteId>virtualdrug</analyteId>
+								<value>2415.5</value>
+								<unit>ug/l</unit>
+							</concentration>
+						</concentrations>
+					</sample>
+					<sample>
+						<sampleId>c1</sampleId>
+						<sampleDate>2023-01-01T12:00:00</sampleDate>
+						<concentrations>
+							<concentration>
+								<analyteId>virtualdrug</analyteId>
+								<value>2288.7</value>
+								<unit>ug/l</unit>
+							</concentration>
+						</concentrations>
+					</sample>
+					<sample>
+						<sampleId>c1</sampleId>
+						<sampleDate>2023-01-01T16:00:00</sampleDate>
+						<concentrations>
+							<concentration>
+								<analyteId>virtualdrug</analyteId>
+								<value>1157.0</value>
+								<unit>ug/l</unit>
+							</concentration>
+						</concentrations>
+					</sample>
+					<sample>
+						<sampleId>c1</sampleId>
+            <sampleDate>2023-01-02T08:00:00</sampleDate>
+						<concentrations>
+							<concentration>
+								<analyteId>virtualdrug</analyteId>
+								<value>68.782</value>
+								<unit>ug/l</unit>
+							</concentration>
+						</concentrations>
+					</sample>
+				</samples>
+			</drug>
+		</drugs>
+	</drugTreatment>"
+                  R"(
+	<!-- List of the requests we want the server to take care of -->
+	<requests>
+		<request>
+		    <requestId>ch.tucuxi.virtualdrug.mod1.stats</requestId>
+		    <drugId>virtualdrug</drugId>
+		    <drugModelId>ch.tucuxi.virtualdrug.mod1</drugModelId>
+                    <percentilesTraits>
+                      <computingOption>
+                        <parametersType>apriori</parametersType>
+                        <compartmentOption>allActiveMoieties</compartmentOption>
+                        <retrieveStatistics>true</retrieveStatistics>
+                        <retrieveParameters>true</retrieveParameters>
+                        <retrieveCovariates>true</retrieveCovariates>
+                      </computingOption>
+                      <nbPointsPerHour>20</nbPointsPerHour>
+                      <dateInterval>
+                          <start>2018-07-06T08:00:00</start>
+                          <end>2018-07-08T08:00:00</end>
+                      </dateInterval>
+                      <ranks>
+                          <rank>-10</rank>
+                          <rank>-1</rank>
+                          <rank>101</rank>
+                          <rank>5000</rank>
+                      </ranks>
+                    </percentilesTraits>
+		</request>
+	</requests>
+</query>)";
+
 
 #endif // GTEST_QUERYINPUTSTRINGS_H


### PR DESCRIPTION
Fixes #1  by checking the percentil rank and ~adapting it~ throwing an error if it's out of bounds.
~Additionally log a message so the user is aware of the problem~

~Also added a test to check that the rank value imported is correctly adapted if it's out of bounds~

```bash
$ tail imatinib.tqf
                  <rank>25</rank>
                  <rank>50</rank>
                  <rank>75</rank>
                  <rank>90</rank>
                  <rank>5000</rank>
              </ranks>
            </percentilesTraits>
        </request>
    </requests>
</query>

$ ./tucucli -d drugs -i imatinib.tqf -o output.xml
[24-12-16 18:13:35.903] 109836 info: ********************************************************
[24-12-16 18:13:35.903] 109836 info: Tucuxi console application is starting up...
[24-12-16 18:13:35.903] 109836 info: Drugs directory : drugs
[24-12-16 18:13:35.904] 109836 info: Input file : imatinib.tqf
[24-12-16 18:13:35.904] 109836 info: Output file name : output.xml
[24-12-16 18:13:35.904] 109836 info: QueryLogs directory : 
[24-12-16 18:13:35.904] 109836 info: Data file directory : 
[24-12-16 18:13:35.904] 109836 info: Tqf copy output file : 
[24-12-16 18:13:35.907] 109836 error: Error, see details : 
<query><requests><request><percentilesTraits><ranks><rank> contains an invalid value : 5000

[24-12-16 18:13:35.908] 109836 info: The response XML file was successfully generated
[24-12-16 18:13:35.908] 109836 info: Tucuxi console application is exiting...
``` 

@ythoma please let me know if this is enough or if you think we should double check the values where they're actually used